### PR TITLE
CI | Only build when push & PR to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: node_js
 node_js:
   - "10"
 
+branches:
+  only:
+    - master
+
 install:
   - npm install
   - npm install codecov -g


### PR DESCRIPTION
Stop Travis doing 2 builds, instead only build when `push to master` or `pushing to PR going in master`.